### PR TITLE
Implement backtesting and pattern detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /opt/moneymaker
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "start_all.py"]

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # MoneyMaker AI
 
-A small demo of an automated trading assistant including:
+An automated trading assistant including:
 
 - FastAPI dashboard with WebSocket stream
 - Telegram bot interaction
-- Simple ML based trading strategy
+- Simple ML based trading strategy with pattern detection
 - systemd service example
+- Backtesting module
+- Dockerfile for container deployment
 
 ## Quick Start
 
@@ -34,3 +36,12 @@ sudo systemctl start moneymaker.service
 ```
 
 Logs will appear in `/var/log/moneymaker.log` and rotated daily as configured in `config/logrotate.conf`.
+
+## Docker
+
+Build and run using Docker:
+
+```bash
+docker build -t moneymaker .
+docker run -p 5000:5000 --env-file .env moneymaker
+```

--- a/backtest.py
+++ b/backtest.py
@@ -1,0 +1,46 @@
+import argparse
+from pathlib import Path
+import pandas as pd
+import matplotlib.pyplot as plt
+from src.strategy import TradingStrategy
+
+
+def run_backtest(path: Path):
+    df = pd.read_csv(path)
+    strategy = TradingStrategy(path.stem, path.parent)
+    strategy.train()
+    balance = 0.0
+    equity = []
+    position = None
+    entry = 0.0
+    for i in range(len(df) - 1):
+        window = df.iloc[: i + 1]
+        signal = strategy.predict_signal(window)
+        price = df.loc[i, 'Close']
+        if signal == 1 and position is None:
+            position = 'long'
+            entry = price
+        elif signal == 0 and position == 'long':
+            balance += price - entry
+            position = None
+        equity.append(balance + (price - entry if position else 0))
+    dd = max(equity) - equity[-1] if equity else 0
+    plt.figure()
+    plt.plot(equity)
+    plt.title('Equity Curve')
+    out = Path('dashboard/static/backtests') / f'{path.stem}_equity.png'
+    plt.savefig(out)
+    plt.close()
+    return balance, dd, out
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('csv', type=Path)
+    args = parser.parse_args()
+    bal, dd, out = run_backtest(args.csv)
+    print(f'Profit: {bal:.2f}, Drawdown: {dd:.2f}, plot: {out}')
+
+
+if __name__ == '__main__':
+    main()

--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -15,12 +15,16 @@ class TelegramBot:
     def __init__(self, token: str, data_dir: Path):
         self.app = ApplicationBuilder().token(token).build()
         self.data_dir = Path(data_dir)
+        self.last_trade: str | None = None
+        self.profit_total: float = 0.0
         self.app.add_handler(CommandHandler('start', self.start))
         self.app.add_handler(CommandHandler('status', self.status))
         self.app.add_handler(CommandHandler('chart', self.chart))
         self.app.add_handler(CommandHandler('log', self.log))
+        self.app.add_handler(CommandHandler('last_trade', self.last_trade))
+        self.app.add_handler(CommandHandler('profit', self.profit))
         self.app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, self.echo))
-
+        
     async def start(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text('MoneyMaker Bot active.')
 
@@ -53,9 +57,22 @@ class TelegramBot:
     async def echo(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text(update.message.text)
 
+    async def last_trade(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        if self.last_trade:
+            await update.message.reply_text(f'Last trade: {self.last_trade}')
+        else:
+            await update.message.reply_text('No trades yet.')
+
+    async def profit(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        await update.message.reply_text(f'Total profit: {self.profit_total:.2f}')
+
     def notify_trade(self, text: str):
         for chat in self.app.bot_data.get('chats', []):
             self.app.create_task(self.app.bot.send_message(chat, text, reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton('Confirm', callback_data='ok')]])))
+        self.last_trade = text
+
+    def record_profit(self, amount: float):
+        self.profit_total += amount
 
     def run(self):
         logger.info('Starting Telegram bot')

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -2,8 +2,8 @@ from pathlib import Path
 import json
 import logging
 import pandas as pd
-from fastapi import FastAPI, WebSocket, Depends, Request
-from fastapi.responses import HTMLResponse
+from fastapi import FastAPI, WebSocket, Depends, Request, UploadFile, File
+from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -25,14 +25,23 @@ def get_current_user(credentials: HTTPBasicCredentials = Depends(security)):
 app = FastAPI()
 app.mount('/static', StaticFiles(directory=Path(__file__).parent / 'static'), name='static')
 
+
+@app.middleware('http')
+async def log_requests(request: Request, call_next):
+    logger.info('Request from %s to %s', request.client.host, request.url.path)
+    response = await call_next(request)
+    return response
+
 templates = Jinja2Templates(directory=Path(__file__).parent / 'templates')
 
 strategy = None
+DATA_DIR = Path('data')
 
 def init(app: FastAPI, data_dir: Path, asset: str, users: dict):
-    global strategy, USERS
+    global strategy, USERS, DATA_DIR
     USERS = users
-    strategy = TradingStrategy(asset, data_dir)
+    DATA_DIR = Path(data_dir)
+    strategy = TradingStrategy(asset, DATA_DIR)
     strategy.train()
     logger.info('Strategy trained for %s', asset)
 
@@ -53,3 +62,27 @@ async def websocket_endpoint(ws: WebSocket):
         except Exception as e:
             logger.exception(e)
             break
+
+
+@app.get('/api/data')
+async def get_data(symbol: str = 'BTCUSDT', user: str = Depends(get_current_user)):
+    path = DATA_DIR / f"{symbol}.csv"
+    if not path.exists():
+        return JSONResponse(status_code=404, content={'error': 'symbol not found'})
+    df = pd.read_csv(path).tail(200)
+    return df.to_dict(orient='records')
+
+
+@app.get('/backtest', response_class=HTMLResponse)
+async def backtest_form(request: Request, user: str = Depends(get_current_user)):
+    return templates.TemplateResponse('backtest.html', {'request': request})
+
+
+@app.post('/backtest', response_class=HTMLResponse)
+async def run_backtest_view(request: Request, file: UploadFile = File(...), user: str = Depends(get_current_user)):
+    content = await file.read()
+    temp = DATA_DIR / 'upload.csv'
+    temp.write_bytes(content)
+    from backtest import run_backtest
+    profit, dd, out = run_backtest(temp)
+    return templates.TemplateResponse('backtest.html', {'request': request, 'profit': profit, 'drawdown': dd, 'plot': out.name})

--- a/dashboard/templates/backtest.html
+++ b/dashboard/templates/backtest.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Backtest</title>
+</head>
+<body>
+<h1>Backtest</h1>
+<form action="/backtest" method="post" enctype="multipart/form-data">
+    <input type="file" name="file" />
+    <button type="submit">Run</button>
+</form>
+{% if profit is defined %}
+<p>Profit: {{ profit }}</p>
+<p>Drawdown: {{ drawdown }}</p>
+<img src="/static/backtests/{{ plot }}" alt="equity curve" />
+{% endif %}
+</body>
+</html>

--- a/dashboard/templates/index.html
+++ b/dashboard/templates/index.html
@@ -7,12 +7,36 @@
 <body>
 <h1>MoneyMaker Dashboard</h1>
 <div id="signal">Waiting...</div>
+<select id="symbol">
+    <option>BTCUSDT</option>
+</select>
+<div id="chart" style="width:800px;height:400px"></div>
+<a href="/backtest">Backtesting</a>
 <script>
 const ws = new WebSocket(`ws://${location.host}/ws`);
 ws.onmessage = (ev) => {
     const data = JSON.parse(ev.data);
     document.getElementById('signal').innerText = data.signal ? 'BUY' : 'SELL';
 };
+
+async function loadChart() {
+    const symbol = document.getElementById('symbol').value;
+    const resp = await fetch(`/api/data?symbol=${symbol}`);
+    const rows = await resp.json();
+    const x = rows.map((r, i) => i);
+    const trace = {
+        x: x,
+        open: rows.map(r => r.Open),
+        high: rows.map(r => r.High),
+        low: rows.map(r => r.Low),
+        close: rows.map(r => r.Close),
+        type: 'candlestick'
+    };
+    Plotly.newPlot('chart', [trace]);
+}
+
+loadChart();
+document.getElementById('symbol').addEventListener('change', loadChart);
 </script>
 </body>
 </html>

--- a/pattern_detector.py
+++ b/pattern_detector.py
@@ -1,0 +1,51 @@
+import pandas as pd
+
+
+def detect_cup_and_handle(df: pd.DataFrame) -> bool:
+    window = 40
+    if len(df) < window:
+        return False
+    prices = df['Close'].tail(window).reset_index(drop=True)
+    mid = prices.idxmin()
+    left_max = prices[:mid].max()
+    right_max = prices[mid:].max()
+    if mid == 0 or mid == window - 1:
+        return False
+    depth = (left_max + right_max) / 2 - prices[mid]
+    return depth > 0 and abs(left_max - right_max) / max(left_max, right_max) < 0.1
+
+
+def detect_flag(df: pd.DataFrame) -> bool:
+    if len(df) < 10:
+        return False
+    segment = df['Close'].tail(10)
+    trend = segment.iloc[-1] - segment.iloc[0]
+    return abs(trend) < segment.std() * 2
+
+
+def detect_pennant(df: pd.DataFrame) -> bool:
+    if len(df) < 10:
+        return False
+    highs = df['High'].tail(10)
+    lows = df['Low'].tail(10)
+    return highs.is_monotonic_decreasing and lows.is_monotonic_increasing
+
+
+def detect_harmonic(df: pd.DataFrame) -> str | None:
+    if len(df) < 5:
+        return None
+    segment = df['Close'].tail(5).reset_index(drop=True)
+    a, b, c, d, e = segment
+    ab = abs(b - a)
+    bc = abs(c - b)
+    cd = abs(d - c)
+    de = abs(e - d)
+    ratio1 = bc / ab if ab else 0
+    ratio2 = cd / bc if bc else 0
+    ratio3 = de / cd if cd else 0
+    if abs(ratio1 - 0.618) < 0.1 and abs(ratio2 - 0.618) < 0.1:
+        if abs(ratio3 - 1.27) < 0.2:
+            return 'Gartley'
+        if abs(ratio3 - 1.618) < 0.2:
+            return 'Butterfly'
+    return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pandas
 scikit-learn
 plotly
 jinja2
+matplotlib

--- a/start_all.py
+++ b/start_all.py
@@ -1,4 +1,5 @@
 import logging
+from logging.handlers import RotatingFileHandler
 import os
 from threading import Thread
 from pathlib import Path
@@ -8,7 +9,19 @@ import uvicorn
 from bot.telegram_bot import TelegramBot
 import dashboard.app as dashboard_module
 
-logging.basicConfig(level=logging.INFO)
+LOG_DIR = Path('logs')
+LOG_DIR.mkdir(exist_ok=True)
+
+activity_handler = RotatingFileHandler(LOG_DIR / 'activity.log', maxBytes=1_000_000, backupCount=3)
+activity_handler.setLevel(logging.INFO)
+error_handler = RotatingFileHandler(LOG_DIR / 'errors.log', maxBytes=1_000_000, backupCount=3)
+error_handler.setLevel(logging.ERROR)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s %(levelname)s %(name)s: %(message)s',
+    handlers=[logging.StreamHandler(), activity_handler, error_handler]
+)
 load_dotenv()
 
 TOKEN = os.getenv('TELEGRAM_TOKEN')


### PR DESCRIPTION
## Summary
- add rotating file logging
- add pattern detector module
- implement backtesting utility
- show candlestick chart with data API
- enable Telegram bot trade info
- add Dockerfile

## Testing
- `python -m py_compile start_all.py bot/telegram_bot.py dashboard/app.py pattern_detector.py backtest.py src/strategy.py`


------
https://chatgpt.com/codex/tasks/task_e_68500e59ad94832cb80f581b7aa0b94e